### PR TITLE
Add support for percentage(%) type of Alpha value

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ If you chose to use "Name that color", this [list of colors](https://github.com/
 * Alpha + Color 
   * **6abc** -> `<color name="casper_alpha_40">#6abc</color>`
   * **60ab12dc** -> `<color name="electric_violet_alpha_38">#60ab12dc</color>`
+* Alpha(%) + Color
+  * **40%abc** -> `<color name="casper_alpha_40">#66AABBCC</color>`
+  * **38%ab12dc** -> `<color name="electric_violet_alpha_38">#61AB12DC</color>`
 
 ### Name that material color
 
@@ -68,7 +71,10 @@ If you chose to use "Name that material color", this [list of material colors](h
 * Alpha + Color 
   * **6abc** -> `<color name="blue_grey_200_alpha_40">#6abc</color>`
   * **60ab12dc** -> `<color name="purple_a700_alpha_38">#60ab12dc</color>`
-
+* Alpha(%) + Color
+  * **40%abc** -> `<color name="blue_grey_200_alpha_40">#66AABBCC</color>`
+  * **38%ab12dc** -> `<color name="purple_a700_alpha_38">#61AB12DC</color>`
+  
 ## Install
 
 In Android Studio, open **Settings** > **Plugins** > **Browse Plugins** and type "**name that color**".

--- a/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/model/HexColor.kt
+++ b/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/model/HexColor.kt
@@ -3,10 +3,13 @@ package il.co.galex.namethatcolor.core.model
 import il.co.galex.namethatcolor.core.util.hsl
 import il.co.galex.namethatcolor.core.util.rgb
 import il.co.galex.namethatcolor.core.util.roundTo2Decimal
+import il.co.galex.namethatcolor.core.util.roundTo2HexString
 
 class HexColor(val input: String) {
 
     private var alpha: String? = null
+    private var hasPercent = false
+    var percentAlpha: Int? = null
     val value: String
 
     init {
@@ -20,12 +23,27 @@ class HexColor(val input: String) {
             cup = cup.substringAfter("#")
         }
 
+        // Add support for Alpha format of percentage : 10%
+        if (cup.contains("%")) {
+            hasPercent = true
+            val alphaValueText = cup.substringBefore("%").trim()
+            if (alphaValueText.isNotEmpty()) {
+                val alphaValue = alphaValueText.toInt()
+                alpha = (alphaValue / 100.0 * 255).roundTo2HexString().toUpperCase()
+                percentAlpha = alphaValue
+            }
+            cup = cup.substringAfter("%")
+        }
+
         when (cup.length) {
             3 -> {
                 this.value = cup[0] + cup[0] + cup[1] + cup[1] + cup[2] + cup[2]
             }
 
             4 -> {
+                if (hasPercent) {
+                    throw IllegalArgumentException("Length is weird")
+                }
                 this.value = cup[1] + cup[1] + cup[2] + cup[2] + cup[3] + cup[3]
                 this.alpha = cup[0] + cup[0]
             }
@@ -35,6 +53,9 @@ class HexColor(val input: String) {
             }
 
             8 -> {
+                if (hasPercent) {
+                    throw IllegalArgumentException("Length is weird")
+                }
                 this.value = cup.substring(2)
                 this.alpha = cup.substring(0, 2)
             }
@@ -50,17 +71,16 @@ class HexColor(val input: String) {
             if (!ALPHA_REGEX.matches(it)) {
                 throw IllegalArgumentException("The alpha $alpha is not of a correct format")
             }
+            if (!hasPercent) {
+                percentAlpha = (it.toInt(16) / 255.0).roundTo2Decimal()
+            }
         }
     }
 
     fun rgb() = value.rgb()
     fun hsl() = value.hsl()
 
-    fun percentAlpha(): Int? = alpha?.run { (toInt(16) / 255.0).roundTo2Decimal() }
-
     override fun toString(): String = PREFIX + if (alpha == null) value else "$alpha$value"
-
-    fun inputToString() = if (input.startsWith("#")) input else "$PREFIX$input"
 
     companion object {
         private const val PREFIX = "#"

--- a/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/model/HexColor.kt
+++ b/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/model/HexColor.kt
@@ -7,6 +7,8 @@ import il.co.galex.namethatcolor.core.util.roundTo2Decimal
 class HexColor(val input: String) {
 
     private var alpha: String? = null
+    private var hasPercent = false
+    var percentAlpha: Int = 0
     val value: String
 
     init {
@@ -20,12 +22,23 @@ class HexColor(val input: String) {
             cup = cup.substringAfter("#")
         }
 
+        // Add support for Alpha format of percentage : 10%
+        if (cup.contains("%")) {
+            hasPercent = true
+            percentAlpha = cup.substringBefore("%").toInt()
+            alpha = (percentAlpha / 100.0 * 255).roundTo2HexString().toUpperCase()
+            cup = cup.substringAfter("%")
+        }
+
         when (cup.length) {
             3 -> {
                 this.value = cup[0] + cup[0] + cup[1] + cup[1] + cup[2] + cup[2]
             }
 
             4 -> {
+                if (hasPercent) {
+                    throw IllegalArgumentException("Length is weird")
+                }
                 this.value = cup[1] + cup[1] + cup[2] + cup[2] + cup[3] + cup[3]
                 this.alpha = cup[0] + cup[0]
             }
@@ -35,6 +48,9 @@ class HexColor(val input: String) {
             }
 
             8 -> {
+                if (hasPercent) {
+                    throw IllegalArgumentException("Length is weird")
+                }
                 this.value = cup.substring(2)
                 this.alpha = cup.substring(0, 2)
             }
@@ -50,17 +66,16 @@ class HexColor(val input: String) {
             if (!ALPHA_REGEX.matches(it)) {
                 throw IllegalArgumentException("The alpha $alpha is not of a correct format")
             }
+            if (percentAlpha == 0) {
+                percentAlpha = (it.toInt(16) / 255.0).roundTo2Decimal()
+            }
         }
     }
 
     fun rgb() = value.rgb()
     fun hsl() = value.hsl()
 
-    fun percentAlpha(): Int? = alpha?.run { (toInt(16) / 255.0).roundTo2Decimal() }
-
     override fun toString(): String = PREFIX + if (alpha == null) value else "$alpha$value"
-
-    fun inputToString() = if (input.startsWith("#")) input else "$PREFIX$input"
 
     companion object {
         private const val PREFIX = "#"

--- a/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/util/ColorExtensions.kt
+++ b/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/util/ColorExtensions.kt
@@ -3,6 +3,7 @@ package il.co.galex.namethatcolor.core.util
 import il.co.galex.namethatcolor.core.model.Hsl
 import il.co.galex.namethatcolor.core.model.Rgb
 import il.co.galex.namethatcolor.plugin.util.ALPHA_SEPARATOR
+import kotlin.math.roundToInt
 
 /**
  * Transforms a hexadecimal color like "8D90A1" to an Rgb(141, 144, 161)
@@ -47,7 +48,7 @@ fun String.hsl(): Hsl {
         h *= 60
         if (h < 0) h += 360
 
-        return Hsl(h.round(), s.roundTo2Decimal(), l.roundTo2Decimal())
+        return Hsl(h.roundToInt(), s.roundTo2Decimal(), l.roundTo2Decimal())
     }
 }
 

--- a/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/util/Rounding.kt
+++ b/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/core/util/Rounding.kt
@@ -1,4 +1,6 @@
 package il.co.galex.namethatcolor.core.util
 
-fun Double.round() = Math.round(this).toInt()
-fun Double.roundTo2Decimal() = Math.round(this * 100.0).toInt()
+import kotlin.math.roundToInt
+
+fun Double.roundTo2Decimal() = (this * 100.0).roundToInt()
+fun Double.roundTo2HexString() = "%02x".format((this).roundToInt())

--- a/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/plugin/intention/NameColorIntention.kt
+++ b/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/plugin/intention/NameColorIntention.kt
@@ -31,8 +31,8 @@ class NameColorIntention(private val text: String, private val hexColor: HexColo
                     if (oldElement.text.contains(hexColor.input)) {
 
                         val (hexColor, color) = find(HexColor(hexColor.input))
-                        val name = color.name.toXmlName(hexColor.percentAlpha())
-                        val insert = xmlOutput(name, hexColor.inputToString())
+                        val name = color.name.toXmlName(hexColor.percentAlpha)
+                        val insert = xmlOutput(name, hexColor.toString())
 
                         var newElement: PsiElement = XmlElementFactory.getInstance(project).createTagFromText(insert)
                         val split = oldElement.text.split(hexColor.input)

--- a/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/plugin/util/CompletionResultSetExtensions.kt
+++ b/namethatcolor/src/main/kotlin/il/co/galex/namethatcolor/plugin/util/CompletionResultSetExtensions.kt
@@ -11,8 +11,8 @@ inline fun CompletionResultSet.addElement(message: String, clipboard: String, fi
 
     try {
         val (hexColor, color) = find(HexColor(clipboard))
-        val name = color.name.toXmlName(hexColor.percentAlpha())
-        val insert = xmlOutput(name, hexColor.inputToString())
+        val name = color.name.toXmlName(hexColor.percentAlpha)
+        val insert = xmlOutput(name, hexColor.toString())
         addElement(LookupElementBuilder.create(insert).withPresentableText(message))
 
     } catch (e: ColorNotFoundException) {

--- a/namethatcolor/src/test/kotlin/il/co/galex/namethatcolor/core/model/HexColorTest.kt
+++ b/namethatcolor/src/test/kotlin/il/co/galex/namethatcolor/core/model/HexColorTest.kt
@@ -1,88 +1,124 @@
 package il.co.galex.namethatcolor.core.model
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class HexColorTest {
 
     @Test
     fun `input color of 3 chars`() {
-        assertEquals(HexColor("32D").toString(), "#3322DD")
+        assertEquals("#3322DD", HexColor("32D").toString())
     }
 
     @Test
     fun `input color of 3 chars with lowercase letters`() {
-        assertEquals(HexColor("32d").toString(), "#3322DD")
+        assertEquals("#3322DD", HexColor("32d").toString())
     }
 
     @Test
     fun `input color of 3 chars with #`() {
-        assertEquals(HexColor("#32D").toString(), "#3322DD")
+        assertEquals("#3322DD", HexColor("#32D").toString())
     }
 
     @Test
     fun `input color of 3 chars with # and lowercase letters`() {
-        assertEquals(HexColor("#ddd").toString(), "#DDDDDD")
+        assertEquals("#DDDDDD", HexColor("#ddd").toString())
     }
 
     @Test
     fun `input color of 3 chars with alpha`() {
-        assertEquals(HexColor("032D").toString(), "#003322DD")
+        assertEquals("#003322DD", HexColor("032D").toString())
     }
 
     @Test
     fun `input color of 3 chars with alpha and #`() {
-        assertEquals(HexColor("#A32D").toString(), "#AA3322DD")
+        assertEquals("#AA3322DD", HexColor("#A32D").toString())
     }
 
     @Test
     fun `input color of 6 chars`() {
-        assertEquals(HexColor("32DAE1").toString(), "#32DAE1")
+        assertEquals("#32DAE1", HexColor("32DAE1").toString())
     }
 
     @Test
     fun `input color of 6 chars with #`() {
-        assertEquals(HexColor("#123456").toString(), "#123456")
+        assertEquals("#123456", HexColor("#123456").toString())
     }
 
     @Test
     fun `input color of 6 chars with alpha`() {
-        assertEquals(HexColor("A1B1C1D1").toString(), "#A1B1C1D1")
+        assertEquals("#A1B1C1D1", HexColor("A1B1C1D1").toString())
     }
 
     @Test
     fun `input color of 6 chars with alpha and #`() {
-        assertEquals(HexColor("#AA93214F").toString(), "#AA93214F")
+        assertEquals("#AA93214F", HexColor("#AA93214F").toString())
     }
 
     @Test
     fun `alpha of 0 percent`() {
-        assertEquals(HexColor("#0931").percentAlpha(), 0)
+        assertEquals(0, HexColor("#0931").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 0%`() {
+        assertEquals(0, HexColor("#0%931").percentAlpha)
+        assertEquals("#00993311", HexColor("#0%931").toString())
     }
 
     @Test
     fun `alpha of 5 percent`() {
-        assertEquals(HexColor("#0D93214F").percentAlpha(), 5)
+        assertEquals(5, HexColor("#0D93214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 5%`() {
+        assertEquals(5, HexColor("#5%93214F").percentAlpha)
+        assertEquals("#0D93214F", HexColor("#5%93214F").toString())
     }
 
     @Test
     fun `alpha of 25 percent`() {
-        assertEquals(HexColor("#4093214F").percentAlpha(), 25)
+        assertEquals(25, HexColor("#4093214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 25%`() {
+        assertEquals(25, HexColor("#25%93214F").percentAlpha)
+        assertEquals("#4093214F", HexColor("#25%93214F").toString())
     }
 
     @Test
     fun `alpha of 50 percent`() {
-        assertEquals(HexColor("#8093214F").percentAlpha(), 50)
+        assertEquals(50, HexColor("#8093214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 50%`() {
+        assertEquals(50, HexColor("#50%93214F").percentAlpha)
+        assertEquals("#8093214F", HexColor("#50%93214F").toString())
     }
 
     @Test
     fun `alpha of 75 percent`() {
-        assertEquals(HexColor("#BF93214F").percentAlpha(), 75)
+        assertEquals(75, HexColor("#BF93214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 75%`() {
+        assertEquals(75, HexColor("#75%93214F").percentAlpha)
+        assertEquals("#BF93214F", HexColor("#75%93214F").toString())
     }
 
     @Test
     fun `alpha of 100 percent`() {
-        assertEquals(HexColor("#FF93214F").percentAlpha(), 100)
+        assertEquals(100, HexColor("#FF93214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 100%`() {
+        assertEquals(100, HexColor("#100%93214F").percentAlpha)
+        assertEquals("#FF93214F", HexColor("#100%93214F").toString())
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/namethatcolor/src/test/kotlin/il/co/galex/namethatcolor/core/model/HexColorTest.kt
+++ b/namethatcolor/src/test/kotlin/il/co/galex/namethatcolor/core/model/HexColorTest.kt
@@ -1,88 +1,134 @@
 package il.co.galex.namethatcolor.core.model
 
-import org.junit.Assert.*
+import il.co.galex.namethatcolor.core.util.toXmlName
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class HexColorTest {
 
     @Test
     fun `input color of 3 chars`() {
-        assertEquals(HexColor("32D").toString(), "#3322DD")
+        assertEquals("#3322DD", HexColor("32D").toString())
     }
 
     @Test
     fun `input color of 3 chars with lowercase letters`() {
-        assertEquals(HexColor("32d").toString(), "#3322DD")
+        assertEquals("#3322DD", HexColor("32d").toString())
     }
 
     @Test
     fun `input color of 3 chars with #`() {
-        assertEquals(HexColor("#32D").toString(), "#3322DD")
+        assertEquals("#3322DD", HexColor("#32D").toString())
     }
 
     @Test
     fun `input color of 3 chars with # and lowercase letters`() {
-        assertEquals(HexColor("#ddd").toString(), "#DDDDDD")
+        assertEquals("#DDDDDD", HexColor("#ddd").toString())
     }
 
     @Test
     fun `input color of 3 chars with alpha`() {
-        assertEquals(HexColor("032D").toString(), "#003322DD")
+        assertEquals("#003322DD", HexColor("032D").toString())
     }
 
     @Test
     fun `input color of 3 chars with alpha and #`() {
-        assertEquals(HexColor("#A32D").toString(), "#AA3322DD")
+        assertEquals("#AA3322DD", HexColor("#A32D").toString())
     }
 
     @Test
     fun `input color of 6 chars`() {
-        assertEquals(HexColor("32DAE1").toString(), "#32DAE1")
+        assertEquals("#32DAE1", HexColor("32DAE1").toString())
     }
 
     @Test
     fun `input color of 6 chars with #`() {
-        assertEquals(HexColor("#123456").toString(), "#123456")
+        assertEquals("#123456", HexColor("#123456").toString())
     }
 
     @Test
     fun `input color of 6 chars with alpha`() {
-        assertEquals(HexColor("A1B1C1D1").toString(), "#A1B1C1D1")
+        assertEquals("#A1B1C1D1", HexColor("A1B1C1D1").toString())
     }
 
     @Test
     fun `input color of 6 chars with alpha and #`() {
-        assertEquals(HexColor("#AA93214F").toString(), "#AA93214F")
+        assertEquals("#AA93214F", HexColor("#AA93214F").toString())
     }
 
     @Test
     fun `alpha of 0 percent`() {
-        assertEquals(HexColor("#0931").percentAlpha(), 0)
+        assertEquals(0, HexColor("#0931").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 0%`() {
+        assertEquals(0, HexColor("#0%931").percentAlpha)
+        assertEquals("#00993311", HexColor("#0%931").toString())
     }
 
     @Test
     fun `alpha of 5 percent`() {
-        assertEquals(HexColor("#0D93214F").percentAlpha(), 5)
+        assertEquals(5, HexColor("#0D93214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 5%`() {
+        assertEquals(5, HexColor("#5%93214F").percentAlpha)
+        assertEquals("#0D93214F", HexColor("#5%93214F").toString())
     }
 
     @Test
     fun `alpha of 25 percent`() {
-        assertEquals(HexColor("#4093214F").percentAlpha(), 25)
+        assertEquals(25, HexColor("#4093214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 25%`() {
+        assertEquals(25, HexColor("#25%93214F").percentAlpha)
+        assertEquals("#4093214F", HexColor("#25%93214F").toString())
     }
 
     @Test
     fun `alpha of 50 percent`() {
-        assertEquals(HexColor("#8093214F").percentAlpha(), 50)
+        assertEquals(50, HexColor("#8093214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 50%`() {
+        assertEquals(50, HexColor("#50%93214F").percentAlpha)
+        assertEquals("#8093214F", HexColor("#50%93214F").toString())
     }
 
     @Test
     fun `alpha of 75 percent`() {
-        assertEquals(HexColor("#BF93214F").percentAlpha(), 75)
+        assertEquals(75, HexColor("#BF93214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 75%`() {
+        assertEquals(75, HexColor("#75%93214F").percentAlpha)
+        assertEquals("#BF93214F", HexColor("#75%93214F").toString())
     }
 
     @Test
     fun `alpha of 100 percent`() {
-        assertEquals(HexColor("#FF93214F").percentAlpha(), 100)
+        assertEquals(100, HexColor("#FF93214F").percentAlpha)
+    }
+
+    @Test
+    fun `alpha of 100%`() {
+        assertEquals(100, HexColor("#100%93214F").percentAlpha)
+        assertEquals("#FF93214F", HexColor("#100%93214F").toString())
+    }
+
+    @Test
+    fun `ignore default alpha value`() {
+        assertEquals("black", "black".toXmlName(HexColor("000000").percentAlpha))
+        assertEquals("black", "black".toXmlName(HexColor("%000000").percentAlpha))
+        assertEquals("black_alpha_100", "black".toXmlName(HexColor("100%000000").percentAlpha))
+        assertEquals("black_alpha_0", "black".toXmlName(HexColor("0%000000").percentAlpha))
+        assertEquals("black_alpha_10", "black".toXmlName(HexColor("10%000000").percentAlpha))
     }
 
     @Test(expected = IllegalArgumentException::class)


### PR DESCRIPTION
- In most cases, Alpha value will show as percentage. Supporting
  input of percentage can be more convenience.
- Exchange the position of expected and actual value in test cases.