### PR TITLE
Add support for Android Studio 4.0

### DIFF
--- a/namethatcolor/build.gradle
+++ b/namethatcolor/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 intellij {
-    version '2019.2'
+    version '2020.1'
     pluginName 'NameThatColor'
     type 'AI'
 }


### PR DESCRIPTION
Changed 'intellij version' in build.gradle from 2019.2 to 2020.1, plugin could be installed/used in Android Studio (build 193.6911.18.40.6514223).